### PR TITLE
Setup proper .prow boilerplate (including e2e tests)

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,24 +1,4 @@
 presubmits:
-  - name: pull-kubermatic-bulward-validate-prow-yaml
-    always_run: true
-    decorate: true
-    clone_uri: ssh://git@github.com/kubermatic/bulward.git
-    extra_refs:
-      - org: kubermatic
-        repo: infra
-        base_ref: master
-        clone_uri: git@github.com:kubermatic/infra.git
-    spec:
-      containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20200203-711d3732b
-          command:
-            - /app/prow/cmd/checkconfig/app.binary
-          args:
-            - --plugin-config=/home/prow/go/src/github.com/kubermatic/infra/prow/plugins.yaml
-            - --config-path=/home/prow/go/src/github.com/kubermatic/infra/prow/config.yaml
-            - --job-config-path=/home/prow/go/src/github.com/kubermatic/infra/prow/jobs
-            - --prow-yaml-repo-name=$(REPO_OWNER)/$(REPO_NAME)
-
   - name: pull-bulward-test
     always_run: true
     decorate: true
@@ -36,7 +16,6 @@ presubmits:
           resources:
             requests:
               cpu: 4
-
   - name: pull-bulward-lint
     always_run: true
     decorate: true
@@ -55,7 +34,98 @@ presubmits:
                 requests:
                   cpu: 4
                   memory: 6Gi
-
+  - name: pull-bulward-e2e-v1.16
+    always_run: true
+    decorate: true
+    clone_uri: ssh://git@github.com/kubermatic/bulward.git
+    spec:
+      # DNS configuration allows inner cluster to access the internet.
+      dnsPolicy: "None"
+      dnsConfig:
+        nameservers:
+          - 1.1.1.1 # Cloudflare DNS servers
+          - 1.0.0.1
+      containers:
+        - image: quay.io/kubermatic/bulward-test
+          imagePullPolicy: Always
+          name: e2e-test
+          command:
+            - go-init
+            - -main
+            - make e2e-test
+          env:
+            - name: KIND_NODE_IMAGE
+              value: "kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765"
+            - name: GO111MODULE
+              value: "on"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: kubecarrier-aws
+                  key: key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: kubecarrier-aws
+                  key: key_secret
+            - name: AWS_DEFAULT_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: kubecarrier-aws
+                  key: region
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 3
+              memory: 4Gi
+  - name: pull-bulward-e2e-v1.17
+    always_run: true
+    decorate: true
+    clone_uri: ssh://git@github.com/kubermatic/bulward.git
+    spec:
+      # DNS configuration allows inner cluster to access the internet.
+      dnsPolicy: "None"
+      dnsConfig:
+        nameservers:
+          - 1.1.1.1 # Cloudflare DNS servers
+          - 1.0.0.1
+      containers:
+        - image: quay.io/kubermatic/bulward-test
+          imagePullPolicy: Always
+          name: e2e-test
+          command:
+            - go-init
+            - -main
+            - make e2e-test
+          env:
+            - name: KIND_NODE_IMAGE
+              value: "kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a"
+            - name: GO111MODULE
+              value: "on"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: kubecarrier-aws
+                  key: key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: kubecarrier-aws
+                  key: key_secret
+            - name: AWS_DEFAULT_REGION
+              valueFrom:
+                secretKeyRef:
+                  name: kubecarrier-aws
+                  key: region
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 3
+              memory: 4Gi
 postsubmits:
   - name: post-bulward-test-image
     decorate: true

--- a/config/dockerfiles/test.Dockerfile
+++ b/config/dockerfiles/test.Dockerfile
@@ -28,19 +28,28 @@ RUN apt-get -qq update && apt-get -qqy install \
   && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://get.docker.com | sh
+RUN curl -sL --output /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.18.3/bin/linux/amd64/kubectl && chmod a+x /usr/local/bin/kubectl
+RUN curl -sL https://github.com/kubernetes-sigs/apiserver-builder-alpha/releases/download/v1.18.0/apiserver-builder-alpha-v1.18.0-linux-amd64.tar.gz | tar -xz -C /usr/local
+RUN curl -sL --output /usr/local/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-linux-amd64 && chmod a+x /usr/local/bin/kind
+RUN curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.6.1/kustomize_v3.6.1_linux_amd64.tar.gz | tar -xz -C /usr/local/bin
 RUN curl -sL https://dl.google.com/go/go1.14.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN curl -sL --output /tmp/boilerplate.zip https://github.com/kubermatic-labs/boilerplate/releases/download/v0.1.1/boilerplate_0.1.1_linux_amd64.zip && unzip /tmp/boilerplate.zip -d /usr/local/bin && rm -Rf /tmp/boilerplate.zip
 ENV PATH=${PATH}:/usr/local/go/bin:/root/go/bin
 # Allowed to use path@version syntax
 ENV GO111MODULE=on
 RUN go env
 
+ARG kubebuilder_version=2.1.0
+RUN curl -sL https://go.kubebuilder.io/dl/${kubebuilder_version}/linux/amd64 | tar -xz -C /tmp/ && mv /tmp/kubebuilder_${kubebuilder_version}_linux_amd64 /usr/local/kubebuilder
+
 # binary will be $(go env GOPATH)/bin/golangci-lint
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.27.0
 RUN go get golang.org/x/tools/cmd/goimports
+RUN go get github.com/pablo-ruth/go-init
 # Install controller-gen in the dockerfile, otherwise it will be installed during `make generate` which will modify the go.mod
 # and go.sum files, and make the directory dirty.
 RUN go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.9
-RUN pip3 install pre-commit
+RUN pip3 install pre-commit awscli yq
 
 WORKDIR /src
 

--- a/hack/audit.yaml
+++ b/hack/audit.yaml
@@ -1,0 +1,29 @@
+# https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  # ignore pod log requests
+  - level: None
+    resources:
+      - group: ""
+        resources:
+          - "pods/log"
+          - "pods/status"
+  - level: Request
+    resources:
+      - group: "rbac.authorization.k8s.io"
+  - level: RequestResponse
+    resources:
+      - group: "authorization.k8s.io"
+        resources:
+          - "subjectaccessreviews"
+    omitStages:
+      - "RequestReceived"
+  # ignore all kube-system namespace originating requests
+  - level: None
+    namespaces:
+      - "kube-system"
+  - level: Metadata
+    # A bit quality of life, only log completed requests with their reponse
+    omitStages:
+      - "RequestReceived"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Bulward Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file should ONLY be called from within Makefile!!!
+set -euo pipefail
+
+JOB_LOG=${PULL_NUMBER:-}-${JOB_NAME:-}-${BUILD_ID:-}
+workdir=$(mktemp -d)
+if [[ "${JOB_LOG}" != "--" ]]; then
+  workdir=${workdir}/${JOB_LOG}
+  mkdir -p ${workdir}
+fi
+
+function cleanup() {
+  echo "starting cleanup & log upload"
+  kind export logs --name bulward ${workdir}
+  docker cp bulward-control-plane:/var/log/kube-apiserver-audit.log ${workdir}/audit.log
+  echo "find all logs in ${workdir}"
+
+  # https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
+  if [[ "${JOB_LOG}" != "--" ]]; then
+    tmpdir=$(mktemp -d)
+    pushd ${workdir};
+    zip --quiet -r "${tmpdir}/${JOB_LOG}.zip" .
+    popd;
+
+    # TODO Implement bulward one
+    aws s3 cp "${tmpdir}/${JOB_LOG}.zip" "s3://e2elogs.kubecarrier.io/${JOB_LOG}.zip"
+    echo "https://s3.eu-central-1.amazonaws.com/e2elogs.kubecarrier.io/${JOB_LOG}.zip"
+  fi
+}
+
+trap cleanup EXIT
+go test ./test/... | tee ${workdir}/test.out

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -1,0 +1,26 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            audit-log-path: "/var/log/kube-apiserver-audit.log"
+            audit-policy-file: /var/run/hack/audit.yaml
+          extraVolumes:
+            - name: "hack"
+              hostPath: "/var/run/hack"
+              mountPath: "/var/run/hack"
+              readOnly: true
+              pathType: Directory
+            - name: "log"
+              hostPath: "/var/log"
+              mountPath: "/var/log"
+              readOnly: false
+              pathType: Directory
+    extraMounts:
+      - containerPath: /var/run/hack
+        hostPath: /tmp/bulward-hack
+        readOnly: true

--- a/test/noop_test.go
+++ b/test/noop_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2020 The Bulward Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enhances the necessary boilerplate:
* Makefile has better dependency resolution, thus cluster creation & image building is parallel
* removes `validate-prow-yaml` since it will be moved to infra repo
* Setup e2e tests
* adds kubernetes audit logging + log exporting for e2e tests.

```release-note
NONE
```
