### PR TITLE
fixed unnecessary go.mod version pinning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,10 +19,6 @@ require (
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 
-replace sigs.k8s.io/controller-tools => sigs.k8s.io/controller-tools v0.1.12
-
-replace sigs.k8s.io/kubebuilder => sigs.k8s.io/kubebuilder v1.0.8
-
 replace github.com/markbates/inflect => github.com/markbates/inflect v1.0.4
 
 replace github.com/kubernetes-incubator/reference-docs => github.com/kubernetes-sigs/reference-docs v0.0.0-20170929004150-fcf65347b256

--- a/go.sum
+++ b/go.sum
@@ -576,9 +576,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7 h1:uuHDyjllyzRyCI
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
 sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvOk9NM=
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
-sigs.k8s.io/controller-tools v0.1.12 h1:LW8Tfywz+epjYiySSOYWFQl1O1y0os+ZWf22XJmsFww=
 sigs.k8s.io/controller-tools v0.1.12/go.mod h1:6g08p9m9G/So3sBc1AOQifHfhxH/mb6Sc4z0LMI8XMw=
-sigs.k8s.io/kubebuilder v1.0.8 h1:XYctSbuOICM9z1Ok0GIWChc1cj90EEEczeJQnb7ZPf0=
 sigs.k8s.io/kubebuilder v1.0.8/go.mod h1:tjcjlckQhPDkbbOw9sUkf1hB1EMiKvqVJhxMXh13npA=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=


### PR DESCRIPTION
**What this PR does / why we need it**:

During `make generatate` @lsviben  had the following issue:

```
go: found sigs.k8s.io/controller-tools/cmd/controller-gen in sigs.k8s.io/controller-tools v0.2.9
# sigs.k8s.io/controller-tools/pkg/webhook
../../../.gvm/pkgsets/go1.14.2/global/pkg/mod/sigs.k8s.io/controller-tools@v0.1.12/pkg/webhook/generator.go:147:24: undefined: v1beta1.Webhook
../../../.gvm/pkgsets/go1.14.2/global/pkg/mod/sigs.k8s.io/controller-tools@v0.1.12/pkg/webhook/generator.go:185:26: undefined: v1beta1.Webhook
../../../.gvm/pkgsets/go1.14.2/global/pkg/mod/sigs.k8s.io/controller-tools@v0.1.12/pkg/webhook/generator.go:223:82: undefined: v1beta1.Webhook
../../../.gvm/pkgsets/go1.14.2/global/pkg/mod/sigs.k8s.io/controller-tools@v0.1.12/pkg/webhook/generator.go:235:14: undefined: v1beta1.Webhook
```

This PR aims to fix it. 

```release-note
NONE
```
