### PR TITLE
Organization owners should be the only ones with edit privileges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,11 @@ KUBECONFIG ?= ${HOME}/.kube/kind-config-${KIND_CLUSTER}
 SHELL=/bin/bash
 .SHELLFLAGS=-euo pipefail -c
 VERSION = v1
+
 # Debug BUILD_ARGS
 # BUILD_ARGS?=-gcflags "all=-N -l"
-# Release BUILD_ARGS
-# BUILD_ARGS?=-gcflags "all=-w"
+# sudo dlv attach --headless=true -l localhost:9060 --api-version=2 --accept-multiclient  --only-same-user=false <PID>
+# <PID> could be find via pgrep e.g. $(pgrep apiserver -n)
 BUILD_ARGS?=
 
 export CGO_ENABLED:=0

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ KUBECONFIG ?= ${HOME}/.kube/kind-config-${KIND_CLUSTER}
 SHELL=/bin/bash
 .SHELLFLAGS=-euo pipefail -c
 VERSION = v1
+# Debug BUILD_ARGS
+# BUILD_ARGS?=-gcflags "all=-N -l"
+# Release BUILD_ARGS
+# BUILD_ARGS?=-gcflags "all=-w"
+BUILD_ARGS?=
 
 export CGO_ENABLED:=0
 
@@ -40,7 +45,7 @@ bin/windows_amd64/%: GOARGS = GOOS=windows GOARCH=amd64
 
 bin/%:
 	$(eval COMPONENT=$(shell basename $*))
-	$(GOARGS) go build  -o bin/$* cmd/$(COMPONENT)/main.go
+	$(GOARGS) go build $(BUILD_ARGS) -o bin/$* cmd/$(COMPONENT)/main.go
 
 # ---------------
 # Code Generators

--- a/config/apiserver/rbac/kustomization.yaml
+++ b/config/apiserver/rbac/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
 - role_binding.yaml
 - role.yaml
 - service_account.yaml
+- user_clusterrolebinding.yaml
+- user_clusterrole.yaml

--- a/config/apiserver/rbac/user_clusterrole.yaml
+++ b/config/apiserver/rbac/user_clusterrole.yaml
@@ -1,0 +1,13 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bulward:user
+rules:
+- apiGroups:
+  - apiserver.bulward.io
+  resources:
+  - organizations
+  verbs:
+  - '*'

--- a/config/apiserver/rbac/user_clusterrole.yaml
+++ b/config/apiserver/rbac/user_clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: bulward:user
+  name: user
 rules:
 - apiGroups:
   - apiserver.bulward.io

--- a/config/apiserver/rbac/user_clusterrolebinding.yaml
+++ b/config/apiserver/rbac/user_clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: bulward:user
+  name: user
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: bulward:user
+  name: user
 subjects:
 - kind: Group
   name: system:authenticated

--- a/config/apiserver/rbac/user_clusterrolebinding.yaml
+++ b/config/apiserver/rbac/user_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: bulward:user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: bulward:user
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/apis/apiserver/organization_REST.go
+++ b/pkg/apis/apiserver/organization_REST.go
@@ -181,7 +181,9 @@ func (o *OrganizationREST) Create(ctx context.Context, obj runtime.Object, creat
 	if err := createValidation(ctx, obj); err != nil {
 		return nil, err
 	}
-	// here we're not using checkOwnership since we're returning different error
+	// Here we're not using checkOwnership since we're returning different error.
+	// User should always include himself/herself in the Owners list, otherwise, we return BadRequest error to
+	// indicate the request is invalid and cannot be processed.
 	isOwner, err := o.containsUser(ctx, org.Spec.Owners)
 	if err != nil {
 		return nil, err

--- a/pkg/apis/apiserver/organization_REST.go
+++ b/pkg/apis/apiserver/organization_REST.go
@@ -365,7 +365,7 @@ func (o *OrganizationREST) checkIsOwner(ctx context.Context, organization *Organ
 	if err != nil {
 		return err
 	}
-	visible, err := o.memberOf(ctx, organization.Spec.Owners)
+	visible, err := o.isVisible(ctx, organization)
 	if err != nil {
 		return err
 	}

--- a/test/apiserver_organization_test.go
+++ b/test/apiserver_organization_test.go
@@ -197,9 +197,6 @@ func TestVisibleFiltering(t *testing.T) {
 			},
 		},
 	}
-	t.Log("ensuring cluster RBAC")
-	ensureClusterRBAC(t, ctx, cl, testCase)
-
 	t.Log("creating orgs")
 	for _, tc := range testCase {
 		cfg, err := ctrl.GetConfig()
@@ -292,34 +289,4 @@ func TestVisibleFiltering(t *testing.T) {
 			assert.NoError(t, tc.tracer.WaitUntil(ctx, events.IsType(watch.Deleted)))
 		})
 	}
-}
-
-func ensureClusterRBAC(t *testing.T, ctx context.Context, cl *testutil.RecordingClient, testCase []*TestVisibleFilteringTestCase) {
-	t.Log("creating necessary cluster roles/rolebinding")
-	crole := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "bulward:test-visible-filtering",
-		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				Verbs:     []string{rbacv1.VerbAll},
-				APIGroups: []string{apiserverv1alpha1.SchemeGroupVersion.Group},
-				Resources: []string{rbacv1.ResourceAll},
-			},
-		},
-	}
-	crolebinding := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "bulward:test-visible-filtering",
-		},
-		RoleRef: rbacv1.RoleRef{
-			Name: crole.Name,
-			Kind: "ClusterRole",
-		},
-	}
-	for _, tc := range testCase {
-		crolebinding.Subjects = append(crolebinding.Subjects, tc.Subject)
-	}
-	require.NoError(t, cl.EnsureCreated(ctx, crole))
-	require.NoError(t, cl.EnsureCreated(ctx, crolebinding))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Only the organization owner can perform the edit operations on it. 

`system:authenticated` group has full `organization.apiserver.bulward.io` permissions by default. They are still passing through our RBAC layer, thus those are limited for existing organizations, etc. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #16 

This is the last PR required for full organization support. 

```release-note
NONE
```
